### PR TITLE
Updated haxm debug ioctl id and struct to match latest haxm version

### DIFF
--- a/target/i386/hax-interface.h
+++ b/target/i386/hax-interface.h
@@ -227,6 +227,7 @@ struct vcpu_state_t {
 
 struct hax_debug_t {
     uint32_t control;
+    uint32_t reserved;
     uint64_t dr[8];
 } __attribute__ ((__packed__));
 

--- a/target/i386/hax-windows.h
+++ b/target/i386/hax-windows.h
@@ -79,7 +79,7 @@ static inline int hax_invalid_fd(hax_fd fd)
                                               METHOD_BUFFERED, FILE_ANY_ACCESS)
 #define HAX_VCPU_GET_REGS            CTL_CODE(HAX_DEVICE_TYPE, 0x90e, \
                                               METHOD_BUFFERED, FILE_ANY_ACCESS)
-#define HAX_IOCTL_VCPU_DEBUG         CTL_CODE(HAX_DEVICE_TYPE, 0x912, \
+#define HAX_IOCTL_VCPU_DEBUG         CTL_CODE(HAX_DEVICE_TYPE, 0x916, \
                                               METHOD_BUFFERED, FILE_ANY_ACCESS)
 
 #define HAX_VM_IOCTL_NOTIFY_QEMU_VERSION CTL_CODE(HAX_DEVICE_TYPE, 0x910, \


### PR DESCRIPTION
IOCTL id and struct got out of sync, this broke debugging. After this PR everything should get back to working with latest HAXM