### PR TITLE
build/win: Don't generate unnecessary executable

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -22,15 +22,7 @@ QEMU_PROG_BUILD = $(QEMU_PROG)
 else
 # system emulator name
 QEMU_PROG=qemu-system-$(TARGET_NAME)$(EXESUF)
-ifneq (,$(findstring -mwindows,$(SDL_LIBS)))
-# Terminate program name with a 'w' because the linker builds a windows executable.
-QEMU_PROGW=qemu-system-$(TARGET_NAME)w$(EXESUF)
-$(QEMU_PROG): $(QEMU_PROGW)
-	$(call quiet-command,$(OBJCOPY) --subsystem console $(QEMU_PROGW) $(QEMU_PROG),"GEN","$(TARGET_DIR)$(QEMU_PROG)")
-QEMU_PROG_BUILD = $(QEMU_PROGW)
-else
 QEMU_PROG_BUILD = $(QEMU_PROG)
-endif
 endif
 
 PROGS=$(QEMU_PROG) $(QEMU_PROGW)


### PR DESCRIPTION
Namely "qemu-system-ps4w.exe"