### PR TITLE
Fix sflash timeout and retries

### DIFF
--- a/hw/ps4/aeolia/aeolia_sflash.h
+++ b/hw/ps4/aeolia/aeolia_sflash.h
@@ -31,7 +31,7 @@
 #define SFLASH_UNKC2028                 0xC2028
 #define SFLASH_CMD                      0xC202C
 #define SFLASH_UNKC2030                 0xC2030
-#define SFLASH_UNKC2038                 0xC2038
+#define SFLASH_STATUS_WR                0xC2038
 #define SFLASH_STATUS                   0xC203C
 #define SFLASH_STATUS2                  0xC2040
 #define SFLASH_DMA_ADDR                 0xC2044

--- a/hw/ps4/aeolia_pcie.c
+++ b/hw/ps4/aeolia_pcie.c
@@ -157,6 +157,7 @@ typedef struct AeoliaPCIEState {
     uint32_t sflash_dma_addr;
     uint32_t sflash_dma_size;
     uint32_t sflash_unkC3000;
+    uint32_t sflash_status2;
 
     uint32_t icc_doorbell;
     uint32_t icc_status;
@@ -549,6 +550,9 @@ static uint64_t aeolia_pcie_peripherals_read(
     case SFLASH_STATUS:
         value = s->sflash_status;
         break;
+    case SFLASH_STATUS2:
+        value = s->sflash_status2;
+        break;
     case SFLASH_UNKC3000_STATUS:
         value = s->sflash_unkC3000;
         break;
@@ -604,6 +608,9 @@ static void aeolia_pcie_peripherals_write(
         break;
     case SFLASH_STATUS:
         s->sflash_status = value;
+        break;
+    case SFLASH_STATUS_WR:
+        s->sflash_status2 = value;
         break;
     case SFLASH_DMA_ADDR:
         s->sflash_dma_addr = value;


### PR DESCRIPTION
Kernel writes expected/current state to 0xC2038 and expects to read it back from 0xC2040, this appears to signal completion and signifies the step.