### PR TITLE
Use plain files instead of zip for crypto blobs

### DIFF
--- a/configure
+++ b/configure
@@ -2082,23 +2082,6 @@ EOF
 fi
 LIBS="$LIBS -lz"
 
-#########################################
-# libzip check
-
-if test "$libzip" != "no" ; then
-    cat > $TMPC << EOF
-#include <zip.h>
-int main(void) { zip_libzip_version(); return 0; }
-EOF
-    if compile_prog "" "-lzip" ; then
-        :
-    else
-        error_exit "libzip check failed" \
-            "Make sure to have the libzip libs and headers installed."
-    fi
-fi
-LIBS="$LIBS -lzip"
-
 ##########################################
 # lzo check
 


### PR DESCRIPTION
This PR reverts changes done in #4 as it doesn't seem to scale for larger number of blobs.
However it makes a small change which should remove problems with viewing/managing crypto folder: now files are expected to be in folders based on first bytes of the hash, i.e:

`crypto/AABBCC01234567890AABBCC01234567890.bin`

will now be stored in

`crypto/AA/BB/CC/01234567890AABBCC01234567890.bin`

There is a helper script in orbital repo to rearrange files from plain structure to this one.
From the current dump, there should be at most 2 files in one folder with 3 "levels".

There seem to be some overhead (I guess it depends on underlying fs) due to many small files: with latest dump zip folder is 1.2G while on ext4 unpacked files occupy 1.5G. 

On the bright side code is trivial and there is no need for some special tool to manage blobs.

Note: this is untested as I can't seem to run orbital on linux properly (it is stuck way before anything touching samu)